### PR TITLE
Fix memory usage query

### DIFF
--- a/queries/knative-service-memory-usage-query.yml
+++ b/queries/knative-service-memory-usage-query.yml
@@ -41,7 +41,7 @@ spec:
       min("timestamp") as data_start,
       max("timestamp") as data_end,
       sum(amount * "timeprecision") AS service_usage_memory_byte_seconds
-    FROM '{| dataSourceTableName .Report.Inputs.KnativeServiceMemoryUsageDataSource |}'
+    FROM {| dataSourceTableName .Report.Inputs.KnativeServiceMemoryUsageDataSource |}
     WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
     AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     GROUP BY labels['namespace'],labels['label_serving_knative_dev_service']


### PR DESCRIPTION
Without this fix I'm getting this error when retrieving the memory report via `curl "http://127.0.0.1:8080/api/v1/reports/get?name=knative-service-cpu-usage&namespace=metering&format=tab"`:

```
{"error":"report is is failed state, reason: GenerateReportFailed, message: error occurred while generating report: Failed to execute query for Report table hive.default.report_metering_knative_service_memory_usage: presto: query failed (200 OK): \"com.facebook.presto.sql.parser.ParsingException: line 9:6: mismatched input ''hive.default.datasource_metering_knative_service_memory_usage''. Expecting: '(', 'LATERAL', 'UNNEST', \u003cidentifier\u003e\""}% 
```