### PR TITLE
Update for v1 API

### DIFF
--- a/datasources/knative-service-cpu-usage-ds.yml
+++ b/datasources/knative-service-cpu-usage-ds.yml
@@ -1,4 +1,4 @@
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportDataSource
 metadata:
   name: knative-service-cpu-usage

--- a/datasources/knative-service-memory-usage-ds.yml
+++ b/datasources/knative-service-memory-usage-ds.yml
@@ -1,4 +1,4 @@
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportDataSource
 metadata:
   name: knative-service-memory-usage

--- a/install/metering.yml
+++ b/install/metering.yml
@@ -1,39 +1,28 @@
-apiVersion: metering.openshift.io/v1alpha1
-kind: Metering
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
 metadata:
   name: "operator-metering"
 spec:
+  storage:
+    type: "hive"
+    hive:
+      type: "s3"
+      s3:
+        # Manually created bucket
+        bucket: "openshift-metering-storage"
+        region: "us-west-1"
+        # Secret can be created via oc create secret -n openshift-metering generic my-aws-secret --from-literal=aws-access-key-id=<my-key-id>  --from-literal=aws-secret-access-key=<my-key>
+        secretName: "my-aws-secret"
+        createBucket: false
   reporting-operator:
     spec:
       route:
         enabled: true
-
       authProxy:
         enabled: true
-
-        # htpasswdData can contain htpasswd file contents for allowing auth
-        # using a static list of usernames and their password hashes.
-        #
-        # generated htpasswdData using: `htpasswd -nb -s testuser password123`
-        # change REPLACEME to the output of your htpasswd command
-        # Password is "redhat"
         htpasswdData: |
           kubeadmin:{SHA}PHZ8Qa+xKtoUAZDtgts/2TDi76M=
-        # cookieSeed is used to protect the cookie created if accessing the API
-        # via your browser.
-        #
-        # generate a 32 character random string using a command of your choice,
-        # for example: `openssl rand -base64 32 | head -c32; echo`
-        # cookieSeed: "RCFE+QpwGWL2bupP+wv4EIOnYlbaRmto"
-        #
-        # change REPLACEME to the output of your command
         cookieSeed: "UlHzGuwd0xScKlk0UTOvxJI7y0YxR8+2"
-
-        # Enables authenticating using a bearer token from a serviceAccount or user.
-        # It must have have one of the following roles:
-        # "report-exporter", "reporting-admin" or "reporting-viewer"
-        # or it must have permissions granting "GET reports/export":
-        # the export subresource of "reports".
         subjectAccessReviewEnabled: true
         delegateURLsEnabled: true
       resources:
@@ -45,70 +34,41 @@ spec:
           cpu: "100m"
   presto:
     spec:
-      presto:
-        coordinator:
-          resources:
-            requests:
-              memory: "2Gi"
-              cpu: "1"
-            limits:
-              memory: "2Gi"
-              cpu: "1"
-        worker:
-          replicas: 0
-          resources:
-            requests:
-              memory: "2Gi"
-              cpu: "1"
-            limits:
-              memory: "2Gi"
-              cpu: "1"
-      hive:
-        metastore:
-          resources:
-            requests:
-              memory: "650Mi"
-              cpu: "500m"
-            limits:
-              memory: "650Mi"
-              cpu: "500m"
-          storage:
-            create: true
-            # Default to null, which means using the default storage class
-            class: null
-            size: "5Gi"
-        server:
-          resources:
-            requests:
-              memory: "500Mi"
-              cpu: "100m"
-            limits:
-              memory: "500Mi"
-              cpu: "100m"
-  hdfs:
+      coordinator:
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1"
+          limits:
+            memory: "2Gi"
+            cpu: "1"
+      worker:
+        replicas: 0
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1"
+          limits:
+            memory: "2Gi"
+            cpu: "1"
+  hive:
     spec:
-      datanode:
-        replicas: 1
+      metastore:
         resources:
           requests:
-            memory: "250Mi"
-            cpu: "250m"
+            memory: "650Mi"
+            cpu: "500m"
           limits:
-            memory: "250Mi"
-            cpu: "250m"
+            memory: "650Mi"
+            cpu: "500m"
         storage:
-          # Default to null, which means using the default storage class
-          class: null
+          create: true
           size: "5Gi"
-      namenode:
+      server:
         resources:
           requests:
-            memory: "350Mi"
-            cpu: "250m"
+            memory: "500Mi"
+            cpu: "100m"
           limits:
-            memory: "350Mi"
-            cpu: "250m"
-        storage:
-          # Default to null, which means using the default storage class
-          class: null
-          size: "5Gi"
+            memory: "500Mi"
+            cpu: "100m"

--- a/queries/knative-service-cpu-usage-query.yml
+++ b/queries/knative-service-cpu-usage-query.yml
@@ -1,4 +1,4 @@
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportQuery
 metadata:
   name: knative-service-cpu-usage
@@ -7,7 +7,7 @@ spec:
   - name: ReportingStart
     type: time
   - name: ReportingEnd
-    type: timeq
+    type: time
   - default: knative-service-cpu-usage
     name: KnativeServiceCpuUsageDataSource
     type: ReportDataSource

--- a/queries/knative-service-memory-usage-query.yml
+++ b/queries/knative-service-memory-usage-query.yml
@@ -1,4 +1,4 @@
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: ReportQuery
 metadata:
   name: knative-service-memory-usage
@@ -7,7 +7,7 @@ spec:
   - name: ReportingStart
     type: time
   - name: ReportingEnd
-    type: timeq
+    type: time
   - default: knative-service-memory-usage
     name: KnativeServiceMemoryUsageDataSource
     type: ReportDataSource
@@ -31,7 +31,7 @@ spec:
     unit: date
   - name: service_usage_memory_byte_seconds
     type: double
-    unit: bytes_seconds
+    unit: byte_seconds
   query: |
     SELECT
       timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,

--- a/reports/knative-service-cpu-usage-report.yml
+++ b/reports/knative-service-cpu-usage-report.yml
@@ -1,6 +1,6 @@
 # Report showing the overall cpu usage in seconds over
 # the configured period
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: Report
 metadata:
   name: knative-service-cpu-usage

--- a/reports/knative-service-memory-usage-report.yml
+++ b/reports/knative-service-memory-usage-report.yml
@@ -1,5 +1,5 @@
 # Report for showing the averaged memory usage over this time period
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: Report
 metadata:
   name: knative-service-memory-usage


### PR DESCRIPTION
This is an update to make the stuff work with the RedHat's `metering-ocp` operator. It has a slightly different configuration (Metering vs. MeteringConfig CRD).

I was not able to make it work with type: "sharedPVC" storage. There were errors. So I'm using the AWS S3 storage.
